### PR TITLE
Disable Renovate Docker image updates for vendored sub-charts

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,18 +3,21 @@
     'github>giantswarm/renovate-presets:default.json5',
     'github>giantswarm/renovate-presets:disable-vendir.json5',
   ],
+  ignorePaths: [
+    'helm/*/charts/**',
+  ],
   customManagers: [
     {
       customType: 'regex',
       managerFilePatterns: [
-        '/(^|/)vendir\\.yml$/',
+        '/(^|/)vendir\.yml$/',
       ],
       matchStrings: [
         'ref: (?<currentValue>kubescape-operator-[\\d.]+)',
       ],
       depNameTemplate: 'kubescape/helm-charts',
       datasourceTemplate: 'github-tags',
-      versioningTemplate: 'regex:^kubescape-operator-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
+      versioningTemplate: 'regex:^kubescape-operator-(?<major>\\d+)\.(?<minor>\\d+)\.(?<patch>\\d+)$',
     },
   ],
   packageRules: [

--- a/renovate.json5
+++ b/renovate.json5
@@ -10,14 +10,14 @@
     {
       customType: 'regex',
       managerFilePatterns: [
-        '/(^|/)vendir\.yml$/',
+        '/(^|/)vendir\\.yml$/',
       ],
       matchStrings: [
         'ref: (?<currentValue>kubescape-operator-[\\d.]+)',
       ],
       depNameTemplate: 'kubescape/helm-charts',
       datasourceTemplate: 'github-tags',
-      versioningTemplate: 'regex:^kubescape-operator-(?<major>\\d+)\.(?<minor>\\d+)\.(?<patch>\\d+)$',
+      versioningTemplate: 'regex:^kubescape-operator-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
     },
   ],
   packageRules: [


### PR DESCRIPTION
## Summary

Adds `ignorePaths` to `renovate.json5` to prevent Renovate from picking up Docker image updates inside vendored sub-charts.

```json5
ignorePaths: [
  'helm/*/charts/**',
],
```

The pattern `helm/*/charts/**` is intentionally generic so it can be reused across other apps without modification — it covers any chart name under `helm/`, not just `kubescape`.

Sub-charts under `helm/*/charts/` are managed via `vendir` and tracked as a unit through the `kubescape-upstream` package rule. Letting Renovate update individual images inside those vendored charts would create PRs for dependencies we don't own and could break the upstream chart structure.