### PR TITLE
renovate: use disable-upstream-charts preset instead of inline ignorePaths

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,9 +2,7 @@
   extends: [
     'github>giantswarm/renovate-presets:default.json5',
     'github>giantswarm/renovate-presets:disable-vendir.json5',
-  ],
-  ignorePaths: [
-    'helm/*/charts/**',
+    'github>giantswarm/renovate-presets:disable-upstream-charts.json5',
   ],
   customManagers: [
     {


### PR DESCRIPTION
Defining `ignorePaths` directly in the repo's `renovate.json5` overrides the `ignorePaths` from extended presets (like `default.json5`), silently dropping exclusions such as `zz_generated.*` workflow files. This causes Renovate to open unwanted PRs updating generated files it should ignore.

Replace the inline `ignorePaths: ['helm/*/charts/**']` with the `github>giantswarm/renovate-presets:disable-upstream-charts` preset so all preset-defined path exclusions are preserved and merged correctly.